### PR TITLE
Update launch.json

### DIFF
--- a/server/.vscode/launch.json
+++ b/server/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"request": "attach",
 			"port": 6004,
 			"sourceMaps": true,
-			"outDir": "../client/server"
+			"outDir": "${workspaceRoot}/../client/server"
 		}
 	]
 }


### PR DESCRIPTION
VSCode no longer accepts relative paths so `${workspaceRoot}` needs added to `outDir`